### PR TITLE
Add command decorator, and separate aws logic

### DIFF
--- a/src/decortaor/aws-decorator.ts
+++ b/src/decortaor/aws-decorator.ts
@@ -1,0 +1,47 @@
+import CloudProviderDecoratorInterface from "./cloud-provider-decorator-interface";
+import {Command, Option, OptionValues} from "commander";
+import {Profile} from "../constants";
+import {OutputService} from "../services/output/output-service";
+import EngineRequestBuilder from "../engine-request-builder";
+import {Command as CloudChiprCommand} from "cloudchipr-engine/lib/Command";
+import {AwsSubCommand} from "cloudchipr-engine/lib/aws-sub-command";
+import {AWSShellEngineAdapter} from "cloudchipr-engine/lib/adapters/aws-shell-engine-adapter";
+import {EbsResponse} from "cloudchipr-engine/lib/responses/ebs-response";
+
+export default class AwsDecorator implements CloudProviderDecoratorInterface{
+    decorateCommand(command: Command): void {
+        command
+            .addOption(new Option('--account-id <account-id>', 'Account id'))
+            .addOption(new Option('--profile <profile>', 'Profile').default(Profile.DEFAULT))
+    }
+
+    decorateCollectCommand(command: Command): void {
+        const parentOptions = command.parent.opts();
+        command
+            .command('ebs')
+            .option('-f, --filter <type>', 'Filter')
+            .action((options) => {
+                const output = new OutputService();
+                const request = EngineRequestBuilder
+                    .builder()
+                    .setOptions(Object.assign(parentOptions, options) as OptionValues)
+                    .setCommand(CloudChiprCommand.collect())
+                    .setSubCommand(AwsSubCommand.ebs())
+                    .build();
+
+                const engineAdapter = new AWSShellEngineAdapter(process.env.C8R_CUSTODIAN as string)
+                let response = engineAdapter.execute<EbsResponse>(request)
+
+                output.print(response.items, parentOptions.outputFormat)
+            });
+
+        command
+            .command('ec2')
+            .option('-f, --filter <type>', 'Filter')
+            .action((options) => {
+                const output = new OutputService();
+                output.print(parentOptions.region,parentOptions.outputFormat);
+                console.log('collect ec2');
+            });
+    }
+}

--- a/src/decortaor/cloud-provider-decorator-interface.ts
+++ b/src/decortaor/cloud-provider-decorator-interface.ts
@@ -1,0 +1,6 @@
+import {Command} from "commander";
+
+export default interface CloudProviderDecoratorInterface {
+    decorateCommand(command: Command): void;
+    decorateCollectCommand(command: Command): void;
+}

--- a/src/decortaor/decortaor-providert.ts
+++ b/src/decortaor/decortaor-providert.ts
@@ -1,0 +1,14 @@
+import CloudProviderDecoratorInterface from "./cloud-provider-decorator-interface";
+import {CloudProvider} from "../constants";
+import AwsDecorator from "./aws-decorator";
+
+export default class DecoratorProvider {
+    getProvider(cloudProvider: CloudProvider): CloudProviderDecoratorInterface {
+        switch (cloudProvider) {
+            case CloudProvider.AWS:
+                return new AwsDecorator();
+            default:
+                return new AwsDecorator();
+        }
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,66 +1,37 @@
 #!/usr/bin/env node
 
 require('dotenv').config();
-import {Command, Option, OptionValues} from 'commander';
-import EngineRequestBuilder from "./engine-request-builder";
-import {Command as CloudChiprCommand} from "cloudchipr-engine/lib/Command";
-import {AwsSubCommand} from "cloudchipr-engine/lib/aws-sub-command";
-import {AWSShellEngineAdapter} from "cloudchipr-engine/lib/adapters/aws-shell-engine-adapter";
-import {EbsResponse} from "cloudchipr-engine/lib/responses/ebs-response";
-import { OutputService } from './services/output/output-service';
+import {Command, Option} from 'commander';
 import {CloudProvider, Output, OutputFormats, Profile, Region} from "./constants";
+import DecoratorProvider from "./decortaor/decortaor-providert";
 import chalk from 'chalk';
 
-const program = new Command();
-
-const collect = program
+const command = new Command();
+command
   .addOption(new Option('--cloud-provider <cloud-provider>', 'Cloud provider').default(CloudProvider.AWS).choices(Object.values(CloudProvider)))
   .addOption(new Option('--region <region>', 'Region').default(Region.US_EAST_1))
-  .addOption(new Option('--account-id <account-id>', 'Account id'))
   .addOption(new Option('--verbose <verbose>', 'Verbose').default(0))
-  .addOption(new Option('--profile <profile>', 'Profile').default(Profile.DEFAULT))
   .addOption(new Option('--version <version>', 'Version'))
   .addOption(new Option('--dry-run <dry-run>', 'Dry run'))
   .addOption(new Option('--help <help>', 'Help'))
   .addOption(new Option('--output <output>', 'Output').default(Output.DETAILED).choices(Object.values(Output)))
-  .addOption(new Option('--output-format <output-format>', 'Output format').default(OutputFormats.TEXT).choices(Object.values(OutputFormats)))
-  .command('collect');
+  .addOption(new Option('--output-format <output-format>', 'Output format').default(OutputFormats.TEXT).choices(Object.values(OutputFormats)));
 
+const decoratorProvider = (new DecoratorProvider()).getProvider(command.opts().cloudProvider);
+decoratorProvider.decorateCommand(command);
+
+const collect = command.command('collect');
 collect
   .command('all')
   .option('-f, --filter <type>', 'Filter')
   .action((options) => {
   });
 
-collect
-    .command('ebs')
-    .option('-f, --filter <type>', 'Filter')
-    .action((options) => {
-        const output = new OutputService();
-        const request = EngineRequestBuilder
-            .builder()
-            .setOptions(Object.assign(program.opts(), options) as OptionValues)
-            .setCommand(CloudChiprCommand.collect())
-            .setSubCommand(AwsSubCommand.ebs())
-            .build();
-
-        const engineAdapter = new AWSShellEngineAdapter(process.env.C8R_CUSTODIAN as string)
-        let response = engineAdapter.execute<EbsResponse>(request)
-
-        output.print(response.items, program.opts().outputFormat)
-    });
-
-collect
-  .command('ec2')
-  .option('-f, --filter <type>', 'Filter')
-  .action((options) => {
-    const output = new OutputService();
-    output.print(program.opts().region, program.opts().outputFormat);
-    console.log('collect ec2');
-  });
+decoratorProvider.decorateCollectCommand(collect);
+//add here clean and nuke decorators
 
 try {
-    program.parse(process.argv);
+    command.parse(process.argv);
 } catch (e) {
     console.error(chalk.red(chalk.underline('Error:'), e.message));
 }


### PR DESCRIPTION
- Index.js is provider agnostic, it contains only general options and commands
- Each cloud provider has a separate class to decorate custom commands and options